### PR TITLE
Update Main - Carrossel atualizado

### DIFF
--- a/api/destaques.js
+++ b/api/destaques.js
@@ -1,0 +1,25 @@
+// /api/destaques.js
+import { db } from './_firebaseAdmin.js';
+
+export default async function handler(req, res) {
+  try {
+    let query = db.collection('imoveis').where('destaque', '==', true);
+    // opcional: ordenar
+    if (req.query.ordenar !== 'nao') query = query.orderBy('destaqueOrdem', 'asc');
+
+    const snap = await query.get();
+    const destaques = snap.docs.map(doc => {
+      const data = doc.data();
+      return {
+        id: data.id,        // slug público já usado por /api/imoveis/[id]
+        nome: data.nome,
+        foto: data.foto,
+      };
+    });
+
+    return res.status(200).json(destaques);
+  } catch (e) {
+    console.error('Erro ao buscar destaques:', e);
+    return res.status(500).json({ error: 'Erro ao buscar destaques' });
+  }
+}

--- a/api/destaques.js
+++ b/api/destaques.js
@@ -3,23 +3,50 @@ import { db } from './_firebaseAdmin.js';
 
 export default async function handler(req, res) {
   try {
-    let query = db.collection('imoveis').where('destaque', '==', true);
-    // opcional: ordenar
-    if (req.query.ordenar !== 'nao') query = query.orderBy('destaqueOrdem', 'asc');
+    const ordenar = (req.query.ordenar ?? 'sim') !== 'nao';
+    let snap;
 
-    const snap = await query.get();
-    const destaques = snap.docs.map(doc => {
-      const data = doc.data();
-      return {
-        id: data.id,        // slug público já usado por /api/imoveis/[id]
-        nome: data.nome,
-        foto: data.foto,
-      };
-    });
+    // 1) Tenta com orderBy (fica bonito se o índice existir)
+    if (ordenar) {
+      try {
+        snap = await db
+          .collection('imoveis')
+          .where('destaque', '==', true)
+          .orderBy('destaqueOrdem', 'asc')
+          .get();
+      } catch (e) {
+        // 2) Se faltar índice, cai pro plano B sem orderBy
+        console.warn('Sem índice para orderBy(destaqueOrdem); usando fallback.', e.message);
+        snap = await db
+          .collection('imoveis')
+          .where('destaque', '==', true)
+          .get();
+      }
+    } else {
+      // pedido explícito para não ordenar (ordenar=nao)
+      snap = await db
+        .collection('imoveis')
+        .where('destaque', '==', true)
+        .get();
+    }
+
+    if (snap.empty) return res.status(200).json([]);
+
+    // Normaliza os campos esperados pelo carrossel
+    const destaques = snap.docs
+      .map((doc) => {
+        const data = doc.data();
+        return {
+          id: data.id ?? doc.id,                  // seu slug público já usado pela rota de detalhes
+          nome: data.nome ?? 'Imóvel',
+          foto: data.foto ?? data.imagens?.[0] ?? null,
+        };
+      })
+      .filter((d) => d.foto); // só envia se tiver imagem
 
     return res.status(200).json(destaques);
-  } catch (e) {
-    console.error('Erro ao buscar destaques:', e);
-    return res.status(500).json({ error: 'Erro ao buscar destaques' });
+  } catch (error) {
+    console.error('Erro ao buscar destaques:', error);
+    return res.status(500).json({ error: 'Erro ao buscar destaques', detail: error?.message });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2066,23 +2066,6 @@
         "form-data": "^2.5.0"
       }
     },
-    "node_modules/@types/request/node_modules/form-data": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.3.tgz",
-      "integrity": "sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "mime-types": "^2.1.35",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
     "node_modules/@types/send": {
       "version": "0.17.5",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
@@ -2571,14 +2554,30 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/balanced-match": {
@@ -3758,19 +3757,21 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
         "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 0.12"
       }
     },
     "node_modules/fraction.js": {
@@ -6792,9 +6793,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-      "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/src/components/Carrossel.vue
+++ b/src/components/Carrossel.vue
@@ -59,9 +59,9 @@ export default {
     const destaques = ref([])
     const loading = ref(true)
     const erro = ref('')
-    const API_BASE = '/api/destaques'   // ⇦ novo endpoint que retorna [{ id, nome, foto }]
-    const ROTA_BASE = '/imoveis'        // ⇦ ajuste se sua rota de detalhes for outra
-    const fallbackImagem = '/placeholder-carrossel.jpg' // coloque em /public
+    const API_BASE = '/api/destaques'
+    const ROTA_BASE = '/imovel'
+    const fallbackImagem = '/placeholder-carrossel.jpg'
 
     async function carregarDestaques() {
       try {

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -2,13 +2,16 @@
   <header class="bg-mainblue text-white shadow-md z-50">
     <div class="container mx-auto relative flex justify-between items-center px-4 py-3">
       <!-- container do logo -->
-      <div class="flex flex-col items-center gap-y-0.5 sm:flex-row sm:items-center sm:gap-x-2 text-center sm:text-left">
+      <router-link
+        to="/"
+        class="flex flex-col items-center gap-y-0.5 sm:flex-row sm:items-center sm:gap-x-2 text-center sm:text-left transition hover:opacity-80"
+      >
         <img :src="Logo" class="main__logo" alt="Logo MC" />
         <div class="sm:text-center sm:ml-2 leading-tight">
           <div class="text-white font-semibold">Mônica</div>
           <div class="text-white font-semibold">Consultoria</div>
         </div>
-      </div>
+      </router-link>
 
       <!-- Mobile menu button -->
       <button class="sm:hidden" @click="alternarMenu" aria-label="Abrir menu de navegação">
@@ -46,6 +49,7 @@
           </li>
         </ul>
       </nav>
+
       <!-- Navigation - Desktop -->
       <nav class="hidden sm:flex space-x-6">
         <ul class="flex flex-row items-center">
@@ -108,7 +112,6 @@
               <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 32 32" fill="currentColor">
                 <path d="M16.01 2.003c-7.73 0-13.99 6.26-13.99 13.99 0 2.472.654 4.886 1.89 7.012l-1.998 7.184 7.37-1.93c1.986 1.08 4.223 1.646 6.728 1.646 7.73 0 13.99-6.26 13.99-13.99 0-7.73-6.26-13.99-13.99-13.99zm.003 25.15c-2.105 0-4.098-.565-5.84-1.632l-.42-.25-4.374 1.146 1.177-4.235-.273-.438c-1.145-1.836-1.75-3.96-1.75-6.126 0-6.434 5.236-11.67 11.67-11.67s11.67 5.236 11.67 11.67c0 6.435-5.236 11.67-11.67 11.67zm6.057-8.412c-.332-.167-1.963-.968-2.27-1.078-.306-.112-.53-.167-.755.168s-.867 1.078-1.063 1.296c-.195.22-.39.247-.722.083-.33-.166-1.392-.513-2.65-1.635-.98-.872-1.642-1.946-1.835-2.276-.192-.33-.021-.51.145-.678.15-.15.33-.39.495-.585.167-.195.222-.33.332-.55.11-.22.055-.415-.028-.583-.084-.167-.755-1.82-1.035-2.49-.273-.655-.552-.566-.755-.577-.195-.01-.417-.01-.64-.01-.222 0-.583.084-.89.417s-1.17 1.143-1.17 2.79 1.198 3.233 1.365 3.453c.166.22 2.34 3.57 5.667 5.006.792.34 1.41.542 1.892.693.795.253 1.52.218 2.09.132.637-.095 1.963-.8 2.24-1.573.277-.772.277-1.428.195-1.573-.083-.145-.305-.222-.637-.39z"/>
               </svg>
-
               <strong>WhatsApp:</strong>
               <span>(11) 94541-3470</span>
             </a>
@@ -133,10 +136,7 @@ import { Phone, Mail } from 'lucide-vue-next';
 
 export default {
   name: 'Header',
-  components: {
-    Phone,
-    Mail
-  },
+  components: { Phone, Mail },
   data() {
     return {
       Logo,
@@ -150,32 +150,19 @@ export default {
     };
   },
   methods: {
-    alternarMenu() {
-      this.menuAberto = !this.menuAberto;
-    },
-    abrirContato() {
-      this.mostrarContato = true;
-    },
-    fecharContato() {
-      this.mostrarContato = false;
-    },
+    alternarMenu() { this.menuAberto = !this.menuAberto },
+    abrirContato() { this.mostrarContato = true },
+    fecharContato() { this.mostrarContato = false },
     copiarEmail(email) {
       navigator.clipboard.writeText(email)
-        .then(() => {
-          alert('E-mail copiado!');
-        })
-        .catch(err => {
-          console.error('Erro ao copiar e-mail:', err);
-        });
+        .then(() => alert('E-mail copiado!'))
+        .catch(err => console.error('Erro ao copiar e-mail:', err));
     }
   },
   watch: {
-    menuAberto(novoValor) {
-      this.$emit('toggle-menu', novoValor);
-    }
+    menuAberto(novoValor) { this.$emit('toggle-menu', novoValor) }
   }
 };
-
 </script>
 
 <style>
@@ -199,18 +186,8 @@ export default {
 
 /* Animação de fade-in */
 @keyframes fade-in {
-  0% {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  0% { opacity: 0; transform: translateY(20px); }
+  100% { opacity: 1; transform: translateY(0); }
 }
-
-.animate-fade-in {
-  animation: fade-in 0.3s ease-out;
-}
-
+.animate-fade-in { animation: fade-in 0.3s ease-out; }
 </style>


### PR DESCRIPTION
🆙 Atualização
Carrossel.vue
  Atualizado para mostrar nome do imóvel sobreposto à imagem.
  Clique no slide leva à página de detalhes (/imovel/:id).
  Corrigido fallback quando a imagem falha.

🆕 Novo arquivo criado
/api/destaques.js
  Endpoint dedicado a buscar apenas os imóveis marcados com destaque: true.
  Lê da coleção imoveis no Firestore.
  Se possível, ordena pelo campo destaqueOrdem; se não houver índice, faz fallback sem ordenação.
  Normaliza o retorno para { id, nome, foto }, filtrando apenas docs que tenham imagem válida.
  É a fonte oficial usada pelo Carrossel.vue agora.

✅ Resultado prático
O carrossel exibe somente imóveis destacados (via campo destaque: true).
Cada slide mostra o nome do imóvel e, ao clicar, abre a página de detalhes em /imovel/:id.
O erro 500 anterior foi resolvido (fallback para ausência de índice).
Navegação corrigida.